### PR TITLE
proper html escaping

### DIFF
--- a/astrolib/command.py
+++ b/astrolib/command.py
@@ -24,7 +24,7 @@ class Command:
     def paramsChanged(self):
         return False
 
-    def getState(Self):
+    def getState(self):
         return None
 
     def getDescription(self,full=False):

--- a/astrolib/commands/ChannelManagement.py
+++ b/astrolib/commands/ChannelManagement.py
@@ -27,10 +27,11 @@ class ChannelManagement(Command):
     def getState(self):
         tables = []
 
-        cmds = []
-        cmds.append(("Command","Description","Example"))
-        cmds.append(("!settitle &lt;title&gt;","Sets the stream title to 'title'","!settitle This is a stream about games!"))
-        cmds.append(("!setgame &lt;game&gt;","Sets the stream game to 'game'","!setgame Deus Ex"))
+        cmds = [
+            ("Command","Description","Example"),
+            ("!settitle <title>","Sets the stream title to 'title'","!settitle This is a stream about games!"),
+            ("!setgame <game>","Sets the stream game to 'game'","!setgame Deus Ex")
+        ]
 
         tables.append(cmds)
 

--- a/astrolib/commands/MiLight.py
+++ b/astrolib/commands/MiLight.py
@@ -52,7 +52,7 @@ class MiLight(Command):
 
         cmds = []
         cmds.append(("Command","Description","Example"))
-        cmds.append(("!light &lt;r&gt; &lt;g&gt; &lt;b&gt;","Specify an exact colour with RGB values for the light.  Values are between 0 and 255","!light 255 0 128"))
+        cmds.append(("!light <r> <g> <b>","Specify an exact colour with RGB values for the light.  Values are between 0 and 255","!light 255 0 128"))
         cmds.append(("!disco","Makes the light flash between various colours","!disco"))
         cmds.append(("!swirl","Makes the light gently swirl between all the colours","!swirl"))
 


### PR DESCRIPTION
HTML escaping is done in `WebsiteOutput.py` and only there. Turned every `&lt;` etc. anywhere else into `<`. I wrote a `HtmlSafeStr` class that helps with all this. This class is inspired by Ruby on Rails. It's a wrapper to a string that is know to be HTML-safe. If you concatenate a `HtmlSafeStr` object with a `str` object then the `str` object will be escaped and the result of the concatenation will be again returned as `HtmlSafeStr`. This way it would even be possible for e.g. a `getDescription` method to return a HTML string without it being double-escaped and I don't have to care if something I get anywhere in `WebsiteOutput.py` still needs to be escaped or not.

Also I use `<th>` instead of `<td><b>` and properly use `<thead>` and `<tbody>`.